### PR TITLE
Refactor install and uninstall scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,16 +44,25 @@ install_zsh() {
 }
 
 main() {
-  if [ -n "${ZSH_VERSION}" ]; then
-    install_zsh
-  elif [ "${SHELL}" = "/bin/bash" ]; then
-    install_bash
-  else
-    echo "Current shell is not supported, aborting..."
-    return 1
-  fi
+  local shell="$1"
+
+  case "${shell}" in
+    "" | "bash")
+      install_bash
+      ;;
+
+    "zsh")
+      install_zsh
+      ;;
+
+    *)
+      echo "No install script available for '${shell}'."
+      echo "Use a different shell or install manually by adding 'source venv-cli/src/venv-cli/venv-cli.sh' to your shell's RC-file"
+      return 1
+      ;;
+  esac
 
   echo "venv installed"
 }
 
-main
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 _src_dir="${PWD}/src/venv-cli"
 _install_dir="/usr/local/share/venv"
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 _src_dir="${PWD}/src/venv-cli"
 _install_dir="/usr/local/share/venv"
+_source_comment="# Source function script for 'venv' command"
 
 set -e
 
@@ -18,9 +19,13 @@ install_common() {
     sudo cp "${completion_file}" "${completion_target}"
   fi
 
-  # Append line to the shell config file to source the script
-  echo -e "\n# Source function script for 'venv' command" >> "${rcfile}"
-  echo ". ${_install_dir}/venv" >> "${rcfile}"
+  # If line does not already exist in the rc file,
+  # append line to the shell config file to source the venv-cli script
+  if ! command grep -q "${_source_comment}" "${rcfile}"; then
+    echo "${_source_comment}" >> "${rcfile}"
+    echo "source ${_install_dir}/venv" >> "${rcfile}"
+  fi
+
   { set +x; } 2>/dev/null
 }
 
@@ -40,8 +45,10 @@ install_zsh() {
   echo "Command completions currently not supported for zsh"
 
   install_common "${rcfile}"
-  echo "fpath+=( ${_install_dir} )" >> "${rcfile}"
-  echo "autoload -Uz venv" >> "${rcfile}"
+  if ! command grep -q "${_source_comment}" "${rcfile}"; then
+    echo "fpath+=( ${_install_dir} )" >> "${rcfile}"
+    echo "autoload -Uz venv" >> "${rcfile}"
+  fi
 }
 
 main() {

--- a/src/venv-cli/uninstall.sh
+++ b/src/venv-cli/uninstall.sh
@@ -9,13 +9,35 @@ post() {
   sudo rm -r "${_venv_dir}" || true
 }
 
+backup_rcfile() {
+  local rcfile="$1"
+
+  echo -e "# This backup file was created by venv-cli during uninstall" > "${rcfile}.old"
+  cat "${rcfile}" >> "${rcfile}.old"
+  echo "Created backup of ${rcfile} at ${rcfile}.old"
+}
+
+remove_source_lines() {
+  # Remove the 'source' lines and the comment above it
+  local source_lines_to_remove=$(("$1" - 1))
+  local rcfile="$2"
+
+  # Remove a specific number of lines from the rc file.
+  # The result is then redirected to a .tmp rc file, which is then moved to the original rc file.
+  local delete_pattern=",+${source_lines_to_remove}d"
+  sed "\|\# Source function script for 'venv' command|${delete_pattern}" < "${rcfile}" > "${rcfile}.tmp"
+  mv "${rcfile}.tmp" "${rcfile}"
+}
+
 uninstall_common() {
   local rcfile="$1"
   local completion_target="$2"
+  local lines_to_remove="$3"
 
-  # Remove the line from shell config that sources the script
-	sed -i "\|.*Source autocompletions for 'venv' command|d" "${rcfile}"
-	sed -i "\|\. ${_venv_dir}/venv|d" "${rcfile}"
+  if command grep -q "${_venv_dir}/venv" "${rcfile}"; then
+    backup_rcfile "${rcfile}"
+    remove_source_lines "${lines_to_remove}" "${rcfile}"
+  fi
 
   if [ -f "${completion_target}" ]; then
     sudo rm "${completion_target}"
@@ -25,17 +47,21 @@ uninstall_common() {
 uninstall_bash() {
   local rcfile="${HOME}/.bashrc"
   local completion_target="/usr/share/bash-completion/completions/venv"
+  local rcfile_source_lines=2
 
-  uninstall_common "${rcfile}" "${completion_target}"
+  uninstall_common "${rcfile}" "${completion_target}" "${rcfile_source_lines}"
+
+  echo "venv command and completions removed from bash"
 }
 
 uninstall_zsh() {
   local rcfile="${HOME}/.zshrc"
   local completion_target="/usr/local/share/zsh/site-functions/_venv"
+  local rcfile_source_lines=4
 
-  uninstall_common "${rcfile}" "${completion_target}"
-  sed -i "\|fpath+=( ${_install_dir} )|d" "${rcfile}"
-  sed -i "\|autoload -Uz venv|d" "${rcfile}"
+  uninstall_common "${rcfile}" "${completion_target}" "${rcfile_source_lines}"
+
+  echo "venv command and completions removed from zsh"
 }
 
 main() {

--- a/src/venv-cli/uninstall.sh
+++ b/src/venv-cli/uninstall.sh
@@ -13,8 +13,8 @@ uninstall_common() {
   local completion_target="$2"
 
   # Remove the line from shell config that sources the script
-	sed -i "\|.*Source autocompletions for 'venv' command|d" "${HOME}/.bashrc"
-	sed -i "\|\. ${_venv_dir}/venv|d" "${HOME}/.bashrc"
+	sed -i "\|.*Source autocompletions for 'venv' command|d" "${rcfile}"
+	sed -i "\|\. ${_venv_dir}/venv|d" "${rcfile}"
 
   if [ -f "${completion_target}" ]; then
     sudo rm "${completion_target}"
@@ -33,8 +33,8 @@ uninstall_zsh() {
   local completion_target="/usr/local/share/zsh/site-functions/_venv"
 
   uninstall_common "${rcfile}" "${completion_target}"
-  sed -i "\|fpath+=( ${_install_dir} )|d" "${HOME}/.zshrc"
-  sed -i "\|autoload -Uz venv|d" "${HOME}/.zshrc"
+  sed -i "\|fpath+=( ${_install_dir} )|d" "${rcfile}"
+  sed -i "\|autoload -Uz venv|d" "${rcfile}"
 }
 
 main() {

--- a/src/venv-cli/uninstall.sh
+++ b/src/venv-cli/uninstall.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 _venv_dir="/usr/local/share/venv"
 
 set -e


### PR DESCRIPTION
This PR changes the `install.sh` script to make it possible to specify which shell to install for, e.g. `./install.sh bash` or `./install.sh zsh`.

It also fixes the bug where running `uninstall.sh` does not remove the comment line `# Source function script for 'venv' command` from the rc files. 

Closes #7
Closes #27