### PR TITLE
Remove file stem constraints from venv install and lock

### DIFF
--- a/src/venv-cli/venv.sh
+++ b/src/venv-cli/venv.sh
@@ -52,11 +52,11 @@ venv::_check_if_help_requested() {
 venv::_check_install_requirements_file() {
   ### Check whether the first argument matches the pattern for a requirements file.
   ### If not, raises error (silently if called with '-q')
-  local file_pattern="^.*?requirements\.(txt|lock)$"
+  local file_pattern="^.+\.(txt|lock)$"
   if [[ ! "$1" =~ $file_pattern ]]; then
     local message=""
     if [ "$2" != "-q" ]; then
-      message="Input file name must have format '*requirements.txt' or '*requirements.lock', was '$1'"
+      message="Input file name must end with '.txt' or '.lock', was '$1'"
     fi
     venv::raise "${message}"
     return "$?"
@@ -66,11 +66,11 @@ venv::_check_install_requirements_file() {
 venv::_check_lock_requirements_file() {
   ### Check whether the first argument matches the pattern for a lock file.
   ### If not, raises error (silently if called with '-q')
-  local file_pattern="^.*?requirements\.lock$"
+  local file_pattern="^.+\.lock$"
   if [[ ! "$1" =~ $file_pattern ]]; then
     local message=""
     if [ "$2" != "-q" ]; then
-      message="Lock file name must have format '*requirements.lock', was '$1'"
+      message="Lock file name must end with '.lock', was '$1'"
     fi
     venv::raise "${message}"
     return "$?"
@@ -227,7 +227,7 @@ venv::install() {
     echo "This step is skipped if '--skip-lock' or '-s' is specified, or when installing"
     echo "directly from a .lock-file."
     echo
-    echo "The <requirements file> must be in the form '*requirements.[txt|lock]'."
+    echo "The <requirements file> must have file extension '.txt' or '.lock'."
     echo "If no arguments are passed, a default file name of 'requirements.txt'"
     echo "will be used."
     echo
@@ -238,7 +238,7 @@ venv::install() {
     echo
     echo "$ venv install dev-requirements.txt"
     echo
-    echo "$ venv install requirements.txt --skip-lock|-s --no-cache"
+    echo "$ venv install requirements/dev-all.txt --skip-lock|-s --no-cache"
     return "${_success}"
   fi
 
@@ -291,7 +291,7 @@ venv::lock() {
     echo "venv lock [<lock file>|<lock file prefix>]"
     echo
     echo "Lock all installed package versions and write them to <lock file>."
-    echo "The <lock file> must be in the form '*requirements.lock'."
+    echo "The <lock file> must have the file extension '.lock'."
     echo
     echo "If <lock file prefix> is specified instead, locks the requirements to"
     echo "a file called '<lock file prefix>-requirements.lock', e.g."

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Callable, Optional
 
-from tests.types import P, RawFilesDict, RequirementsBase, RequirementsDict
+from tests.types import P, RawFilesDict, RequirementsDict, RequirementsStem
 
 RequirementFiles = dict[str, Path]
 current_python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -54,13 +54,13 @@ def run_command(
 
 
 def collect_requirements(
-    func: Callable[P, tuple[RawFilesDict, RequirementsBase]]
-) -> Callable[P, tuple[RequirementsDict, RequirementsBase]]:
+    func: Callable[P, tuple[RawFilesDict, RequirementsStem]]
+) -> Callable[P, tuple[RequirementsDict, RequirementsStem]]:
     @wraps(func)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> tuple[RequirementsDict, RequirementsBase]:
-        files_dict, requirements_base = func(*args, **kwargs)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> tuple[RequirementsDict, RequirementsStem]:
+        files_dict, requirements_stem = func(*args, **kwargs)
         requirements_dict = {filename: "\n".join(requirements) for filename, requirements in files_dict.items()}
-        return requirements_dict, requirements_base
+        return requirements_dict, requirements_stem
 
     return wrapper
 

--- a/tests/test_venv_install.py
+++ b/tests/test_venv_install.py
@@ -8,7 +8,7 @@ from pytest_cases import parametrize_with_cases
 
 from tests.helpers import run_command, write_files
 from tests.test_venv_install_cases import CasesVenvInstallRequirementstxt, CasesVenvInstallWithLock
-from tests.types import RequirementsBase, RequirementsDict
+from tests.types import RequirementsDict, RequirementsStem
 
 _package_name_regex = re.compile(r"^([a-zA-Z0-9_-]+)\b")
 
@@ -30,11 +30,11 @@ def test_venv_install_not_activated(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.order(after="test_venv_activate.py::test_venv_activate")
-@parametrize_with_cases(argnames=["files", "requirements_base"], cases=CasesVenvInstallRequirementstxt)
+@parametrize_with_cases(argnames=["files", "requirements_stem"], cases=CasesVenvInstallRequirementstxt)
 @pytest.mark.parametrize("use_file_name", [True, False])
 def test_venv_install_requirements(
     files: RequirementsDict,
-    requirements_base: RequirementsBase,
+    requirements_stem: RequirementsStem,
     use_file_name: bool,
     tmp_path: Path,
     capfd: pytest.CaptureFixture,
@@ -42,12 +42,12 @@ def test_venv_install_requirements(
     write_files(files=files, dir=tmp_path)
 
     # Install the requirements
-    if not (requirements_base is RequirementsBase.requirements or use_file_name):
-        pytest.skip(f"Empty file name case only valid for requirements.txt, not {requirements_base}")
+    if not (requirements_stem is RequirementsStem.requirements or use_file_name):
+        pytest.skip(f"Empty file name case only valid for requirements.txt, not {requirements_stem}")
 
     install_file_name = ""
     if use_file_name:
-        install_file_name = f"{requirements_base.value}.txt"
+        install_file_name = f"{requirements_stem.value}.txt"
 
     run_command(
         f"venv install {install_file_name} --skip-lock",
@@ -57,7 +57,7 @@ def test_venv_install_requirements(
 
     # Check pip install log output
     output: str = capfd.readouterr().out
-    assert f"Installing requirements from {requirements_base.value}.txt" in output
+    assert f"Installing requirements from {requirements_stem.value}.txt" in output
 
     installed_line = [line for line in output.splitlines() if line.startswith("Successfully installed")][0]
     requirement_lines = chain.from_iterable(contents.splitlines() for contents in files.values())
@@ -70,16 +70,16 @@ def test_venv_install_requirements(
 
 
 @pytest.mark.order(after="test_venv_activate.py::test_venv_activate")
-@parametrize_with_cases(argnames=["files", "requirements_base"], cases=CasesVenvInstallWithLock)
+@parametrize_with_cases(argnames=["files", "requirements_stem"], cases=CasesVenvInstallWithLock)
 def test_venv_install_with_lock(
     files: RequirementsDict,
-    requirements_base: RequirementsBase,
+    requirements_stem: RequirementsStem,
     tmp_path: Path,
 ):
     write_files(files=files, dir=tmp_path)
 
     run_command(
-        f"venv install {requirements_base}.txt",
+        f"venv install {requirements_stem}.txt",
         cwd=tmp_path,
         activated=True,
     )

--- a/tests/test_venv_install.py
+++ b/tests/test_venv_install.py
@@ -43,7 +43,7 @@ def test_venv_install_requirements(
 
     # Install the requirements
     if not (requirements_stem is RequirementsStem.requirements or use_file_name):
-        pytest.skip(f"Empty file name case only valid for requirements.txt, not {requirements_stem}")
+        pytest.skip(f"Empty file name case only valid for requirements.txt, not {requirements_stem.value}.txt")
 
     install_file_name = ""
     if use_file_name:

--- a/tests/test_venv_install_cases.py
+++ b/tests/test_venv_install_cases.py
@@ -1,28 +1,28 @@
 from tests.helpers import collect_requirements
-from tests.types import RawFilesDict, RequirementsBase
+from tests.types import RawFilesDict, RequirementsStem
 
 
 class CasesVenvInstallRequirementstxt:
     @collect_requirements
-    def case_pypi(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_pypi(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger==2.0.7",
         ]
 
         files = {"requirements.txt": requirements_txt}
-        return files, RequirementsBase.requirements
+        return files, RequirementsStem.requirements
 
     @collect_requirements
-    def case_git(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_git(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger @ git+https://github.com/madzak/python-json-logger@v2.0.7",
         ]
 
         files = {"requirements.txt": requirements_txt}
-        return files, RequirementsBase.requirements
+        return files, RequirementsStem.requirements
 
     @collect_requirements
-    def case_pypi_dev(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_pypi_dev(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger==2.0.7",
         ]
@@ -36,10 +36,10 @@ class CasesVenvInstallRequirementstxt:
             "requirements.txt": requirements_txt,
             "dev-requirements.txt": dev_requirements_txt,
         }
-        return files, RequirementsBase.dev_requirements
+        return files, RequirementsStem.dev_requirements
 
     @collect_requirements
-    def case_git_dev(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_git_dev(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger @ git+https://github.com/madzak/python-json-logger@v2.0.7",
         ]
@@ -53,15 +53,15 @@ class CasesVenvInstallRequirementstxt:
             "requirements.txt": requirements_txt,
             "dev-requirements.txt": dev_requirements_txt,
         }
-        return files, RequirementsBase.dev_requirements
+        return files, RequirementsStem.dev_requirements
 
 
 class CasesVenvInstallWithLock:
     @collect_requirements
-    def case_pypi(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_pypi(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger==2.0.7",
         ]
 
         files = {"requirements.txt": requirements_txt}
-        return files, RequirementsBase.requirements
+        return files, RequirementsStem.requirements

--- a/tests/test_venv_install_cases.py
+++ b/tests/test_venv_install_cases.py
@@ -55,6 +55,35 @@ class CasesVenvInstallRequirementstxt:
         }
         return files, RequirementsStem.dev_requirements
 
+    @collect_requirements
+    def case_pypi_several_nested(self) -> tuple[RawFilesDict, RequirementsStem]:
+        core_txt = [
+            "python-json-logger==2.0.7",
+        ]
+
+        test_txt = [
+            "pytest",
+        ]
+
+        lint_txt = [
+            "black",
+        ]
+
+        all_txt = [
+            "-r core.txt",
+            "-r test.txt",
+            "-r lint.txt",
+            "numpy==1.26.0",
+        ]
+
+        files = {
+            "core.txt": core_txt,
+            "test.txt": test_txt,
+            "lint.txt": lint_txt,
+            "all.txt": all_txt,
+        }
+        return files, RequirementsStem.all
+
 
 class CasesVenvInstallWithLock:
     @collect_requirements

--- a/tests/test_venv_internals.py
+++ b/tests/test_venv_internals.py
@@ -72,7 +72,7 @@ def test_venv_check_install_requirements_file_quiet(capfd: pytest.CaptureFixture
 
 @pytest.mark.order("first")
 @pytest.mark.parametrize(
-    ["filename", "expected"],
+    ["filename", "expected_success"],
     [
         ("requirements.lock", True),
         ("dev-requirements.lock", True),
@@ -95,11 +95,11 @@ def test_venv_check_install_requirements_file_quiet(capfd: pytest.CaptureFixture
         ("dev-requirements.asdf", False),
     ],
 )
-def test_venv_check_lock_requirements_file(filename: str, expected: bool):
+def test_venv_check_lock_requirements_file(filename: str, expected_success: bool):
     """Check that 'venv::_check_lock_requirements_file' works as expected"""
     command = f'venv::_check_lock_requirements_file "{filename}"'
 
-    if expected:
+    if expected_success:
         run_command(command)
     else:
         with pytest.raises(subprocess.CalledProcessError):

--- a/tests/test_venv_internals.py
+++ b/tests/test_venv_internals.py
@@ -27,6 +27,8 @@ def test_check_venv_activated_yes_env(tmp_path: Path):
         ("dev-requirements.lock", True),
         ("prod-requirements.txt", True),
         ("prod-requirements.lock", True),
+        ("requirements/prod-requirements.txt", True),
+        ("requirements/prod-requirements.lock", True),
         ("", False),
         (".", False),
         (".txt", False),
@@ -75,6 +77,7 @@ def test_venv_check_install_requirements_file_quiet(capfd: pytest.CaptureFixture
         ("requirements.lock", True),
         ("dev-requirements.lock", True),
         ("prod-requirements.lock", True),
+        ("requirements/prod-requirements.lock", True),
         ("", False),
         (".", False),
         (".txt", False),
@@ -124,8 +127,10 @@ def test_venv_check_lock_requirements_file_quiet(capfd: pytest.CaptureFixture):
         ("requirements", "requirements"),
         ("requirements.txt", "requirements.lock"),
         ("dev-requirements.txt", "dev-requirements.lock"),
+        ("requirements/requirements.txt", "requirements/requirements.lock"),
         ("requirements.lock", "requirements.lock"),
         ("dev-requirements.lock", "dev-requirements.lock"),
+        ("requirements/requirements.lock", "requirements/requirements.lock"),
     ],
 )
 def test_venv_get_lock_from_requirements(filename: str, expected: str, capfd: pytest.CaptureFixture):
@@ -141,8 +146,10 @@ def test_venv_get_lock_from_requirements(filename: str, expected: str, capfd: py
         ("requirements", "requirements"),
         ("requirements.lock", "requirements.txt"),
         ("dev-requirements.lock", "dev-requirements.txt"),
+        ("requirements/requirements.lock", "requirements/requirements.txt"),
         ("requirements.txt", "requirements.txt"),
         ("dev-requirements.txt", "dev-requirements.txt"),
+        ("requirements/requirements.txt", "requirements/requirements.txt"),
     ],
 )
 def test_venv_get_requirements_from_lock(filename: str, expected: str, capfd: pytest.CaptureFixture):

--- a/tests/test_venv_internals.py
+++ b/tests/test_venv_internals.py
@@ -21,6 +21,10 @@ def test_check_venv_activated_yes_env(tmp_path: Path):
 @pytest.mark.parametrize(
     ["filename", "expected"],
     [
+        ("dev.txt", True),
+        ("dev.lock", True),
+        ("file.txt", True),
+        ("file.lock", True),
         ("requirements.txt", True),
         ("requirements.lock", True),
         ("dev-requirements.txt", True),
@@ -34,8 +38,6 @@ def test_check_venv_activated_yes_env(tmp_path: Path):
         (".txt", False),
         (".lock", False),
         ("asdf", False),
-        ("asdf.txt", False),
-        ("asdf.lock", False),
         ("requirements", False),
         ("dev-requirements", False),
         ("requirements.asdf", False),
@@ -74,6 +76,8 @@ def test_venv_check_install_requirements_file_quiet(capfd: pytest.CaptureFixture
 @pytest.mark.parametrize(
     ["filename", "expected_success"],
     [
+        ("dev.lock", True),
+        ("file.lock", True),
         ("requirements.lock", True),
         ("dev-requirements.lock", True),
         ("prod-requirements.lock", True),
@@ -84,7 +88,6 @@ def test_venv_check_install_requirements_file_quiet(capfd: pytest.CaptureFixture
         (".lock", False),
         ("asdf", False),
         ("asdf.txt", False),
-        ("asdf.lock", False),
         ("requirements", False),
         ("dev-requirements", False),
         ("requirements.txt", False),

--- a/tests/test_venv_lock.py
+++ b/tests/test_venv_lock.py
@@ -6,7 +6,7 @@ from pytest_cases import parametrize, parametrize_with_cases
 
 from tests.helpers import run_command, write_files
 from tests.test_venv_lock_cases import CasesVenvLock
-from tests.types import RequirementsBase, RequirementsDict
+from tests.types import RequirementsDict, RequirementsStem
 
 
 @pytest.mark.order(
@@ -15,26 +15,26 @@ from tests.types import RequirementsBase, RequirementsDict
         "test_venv_fill_credentials.py::test_venv_fill_credentials",
     ]
 )
-@parametrize_with_cases(argnames=["files", "requirements_base"], cases=CasesVenvLock)
+@parametrize_with_cases(argnames=["files", "requirements_stem"], cases=CasesVenvLock)
 @parametrize("use_short_name", [False, True])
 def test_venv_lock(
     files: RequirementsDict,
-    requirements_base: RequirementsBase,
+    requirements_stem: RequirementsStem,
     use_short_name: bool,
     tmp_path: Path,
 ):
     """Checks that we can lock requirements in an environment after installing them"""
     write_files(files=files, dir=tmp_path)
 
-    lock_file_path = f"{requirements_base}.lock"
+    lock_file_path = f"{requirements_stem}.lock"
     if use_short_name:
-        lock_file_arg = requirements_base.split("-")[0] if "-" in requirements_base else ""
+        lock_file_arg = requirements_stem.split("-")[0] if "-" in requirements_stem else ""
     else:
         lock_file_arg = lock_file_path
 
     run_command(
         commands=[
-            f"venv install {requirements_base}.txt --skip-lock",
+            f"venv install {requirements_stem}.txt --skip-lock",
             f"venv lock {lock_file_arg}",
         ],
         cwd=tmp_path,

--- a/tests/test_venv_lock.py
+++ b/tests/test_venv_lock.py
@@ -48,7 +48,7 @@ def test_venv_lock(
 @parametrize(
     "lock_arg",
     [
-        "file.lock",
+        "file.txt",
         "requirements.txt",
         "requirements.asd",
     ],

--- a/tests/test_venv_lock_cases.py
+++ b/tests/test_venv_lock_cases.py
@@ -1,10 +1,10 @@
 from tests.helpers import collect_requirements
-from tests.types import RawFilesDict, RequirementsBase
+from tests.types import RawFilesDict, RequirementsStem
 
 
 class CasesVenvLock:
     @collect_requirements
-    def case_requirements(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_requirements(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger==2.0.7",
             "resolvelib @ git+https://github.com/sarugaku/resolvelib@1.0.1",
@@ -18,10 +18,10 @@ class CasesVenvLock:
             "requirements.txt": requirements_txt,
             "requirements.lock": requirements_lock,
         }
-        return files, RequirementsBase.requirements
+        return files, RequirementsStem.requirements
 
     @collect_requirements
-    def case_dev_requirements(self) -> tuple[RawFilesDict, RequirementsBase]:
+    def case_dev_requirements(self) -> tuple[RawFilesDict, RequirementsStem]:
         requirements_txt = [
             "python-json-logger==2.0.7",
         ]
@@ -41,4 +41,4 @@ class CasesVenvLock:
             "dev-requirements.txt": dev_requirements_txt,
             "dev-requirements.lock": dev_requirements_lock,
         }
-        return files, RequirementsBase.dev_requirements
+        return files, RequirementsStem.dev_requirements

--- a/tests/types.py
+++ b/tests/types.py
@@ -11,3 +11,4 @@ RequirementFiles = dict[str, Path]
 class RequirementsStem(str, Enum):
     requirements = "requirements"
     dev_requirements = "dev-requirements"
+    all = "all"

--- a/tests/types.py
+++ b/tests/types.py
@@ -8,6 +8,6 @@ RequirementsDict = dict[str, str]
 RequirementFiles = dict[str, Path]
 
 
-class RequirementsBase(str, Enum):
+class RequirementsStem(str, Enum):
     requirements = "requirements"
     dev_requirements = "dev-requirements"


### PR DESCRIPTION
This PR removes the file stem constraints when running `venv install` and `venv lock`. 

Before, the file had to have the format `*requirements.txt` or `*requirements.lock`. Now, the `requirements` stem constraint has been removed, meaning all files that end with `.txt` or `.lock` are valid for `venv install`, and `.lock` for `venv lock`.

Closes https://github.com/SallingGroup-AI-and-ML/venv-cli/issues/34